### PR TITLE
Feat/build cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,13 @@ jobs:
         uses: felixmosh/turborepo-gh-artifacts@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
 
       # - name: Lint
       #   run: pnpm lint --api="http://127.0.0.1:9080" --team="side-management"
 
       - name: Build
-        run: pnpm build --api="http://127.0.0.1:9080" --team="side-management"
+        run: pnpm build --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="side-management"
 
       - name: Type check
-        run: pnpm type-check --api="http://127.0.0.1:9080" --team="side-management"
+        run: pnpm type-check --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="side-management"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Lint
-        run: pnpm lint --api="http://127.0.0.1:9080" --team="side-management"
+      # - name: Lint
+      #   run: pnpm lint --api="http://127.0.0.1:9080" --team="side-management"
 
       - name: Build
         run: pnpm build --api="http://127.0.0.1:9080" --team="side-management"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
 
-      # - name: Lint
-      #   run: pnpm lint --api="http://127.0.0.1:9080" --team="side-management"
-      # test
+      - name: Lint
+        run: pnpm lint --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="side-management"
 
       - name: Build
         run: pnpm build --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="side-management"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
 
       # - name: Lint
       #   run: pnpm lint --api="http://127.0.0.1:9080" --team="side-management"
+      # test
 
       - name: Build
         run: pnpm build --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="side-management"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,16 @@ jobs:
       - name: Check dedupe
         run: pnpm dedupe --check
 
-      - name: Type check
-        run: pnpm type-check
+      - name: Turborepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
-        run: pnpm lint
+        run: pnpm lint --api="http://127.0.0.1:9080" --team="side-management"
 
-      - name: Test
-        run: pnpm test
+      - name: Build
+        run: pnpm build --api="http://127.0.0.1:9080" --team="side-management"
+
+      - name: Type check
+        run: pnpm type-check --api="http://127.0.0.1:9080" --team="side-management"


### PR DESCRIPTION
## 작업내용
- remote cach를 이용한 ci skip 추가
- TURBO_SERVER_TOKEN의 추가가 필요합니다.[링크](https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token#creating-an-access-token) 현재는 제가 1일짜리 토큰 하나 넣어뒀습니다.
- [ci skip action lint](https://github.com/side-management/fe/actions/runs/5167294542/jobs/9308090714)
<img width="720" alt="Screen Shot 2023-06-04 at 1 52 05 PM" src="https://github.com/side-management/fe/assets/57468767/3bc34905-b810-412f-b552-840c3e7abd07">

## 연관 이슈
- resolve #22 